### PR TITLE
Fixed aliases and simplified translate

### DIFF
--- a/em.py
+++ b/em.py
@@ -40,20 +40,17 @@ def parse_emojis(filename='emojis.json'):
 def parse_aliases(lookup, filename='aliases.json'):
     data = json.load(open(filename))
 
-    return {k: [lookup[c] for c in v.split()] for k, v in data.iteritems()}
+    return {k: v.split() for k, v in data.iteritems()}
 
 
 def translate(lookup, aliases, code):
-    output = []
     if code[0] == ':' and code[-1] == ':':
         code = code[1:-1]
 
-    if code in aliases:
-        output.extend(aliases[code])
-    else:
-        output.append(lookup.get(code, {'char': None})['char'])
+    output = [code] if code not in aliases else aliases[code]
 
-    return output
+    for name in output:
+        yield None if name not in lookup else lookup[name]['char']
 
 
 def do_list(lookup, aliases, term):


### PR DESCRIPTION
when using aliases, I was getting this error message:

```
python em.py rps
Traceback (most recent call last):
  File "em.py", line 129, in <module>
    cli()
  File "em.py", line 120, in cli
    results = ' '.join(results)
TypeError: sequence item 0: expected string or Unicode, dict found
```

with this PR, `aliases` will only be a dict of the split emoji-string,

so instead of this:

```python
>>> aliases
{
    "kr": [
        {
            "keywords": ["stars", "shine", "shiny", "cool", "awesome", "good", "magic"],
            "char": "\u2728",
            "category": "animals_and_nature"
        },
        {
            "keywords": ["food", "dessert"],
            "char": "\ud83c\udf70",
            "category": "food_and_drink"
        },
        ...
    ],
    "rockstar": [...],
    "rps": [...]
}
```

`aliases` is now this:
```python
>>> aliases
{
    "kr": ["sparkles", "cake", "sparkles"],
    "rps": ["gem", "page_facing_up", "scissors"],
    "rockstar": ["guitar", "star"]
}
```

I also touched up the `translate` function a bit for readability.