### PR TITLE
Bugfix/python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+.tox
+*.egg-info

--- a/em/__init__.py
+++ b/em/__init__.py
@@ -70,7 +70,7 @@ def do_find(lookup, term):
     for name in lookup.keys():
         space[name].append(name)
 
-    for name, definition in lookup.iteritems():
+    for name, definition in lookup.items():
         try:
             iter_lookup = lookup.iteritems()  # Python 2
         except AttributeError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py35
+
+[testenv]
+commands=
+    em cupid
+    em -s heart


### PR DESCRIPTION
The use of `iteritems` stops em from working under Python3, where this method has been renamed to `items`.

There is a difference now in memory usage, because under Python2, items returns an actual list of 2-tuples, whereas in Python3 it returns an iterable. I felt this compromise was better than messing up the code with if-statements on the Python version.

Feedback welcome - happy to do whatever you prefer to get this fix in 👹 📷 ❤️