### PR TITLE
Add missing requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Let's find some emoji, by color::
 Installation
 ------------
 
-At this time, **em** requires Python and pip::
+At this time, **em** requires Python, pip and `xclip`::
 
     $ pip install em-keyboard
 


### PR DESCRIPTION
Without `xclip` on Ubuntu, `em` fails to run.

```
$ em heart
Traceback (most recent call last):
  File "/home/victor/.local/bin/em", line 11, in <module>
    sys.exit(cli())
  File "/home/victor/.local/lib/python2.7/site-packages/em/__init__.py", line 147, in cli
    xerox.copy(results)
  File "/home/victor/.local/lib/python2.7/site-packages/xerox/x11.py", line 22, in copy
    raise XclipNotFound
xerox.base.XclipNotFound
```
